### PR TITLE
fix handling of 0 size files

### DIFF
--- a/upload/handler.go
+++ b/upload/handler.go
@@ -345,7 +345,8 @@ func (h *S3ndHandler) parseRequest(task *UploadTask, r *http.Request) error {
 		return errors.Wrapf(err, "could not stat file %v", *task.File)
 	}
 	task.SizeBytes = fStat.Size()
-	task.UploadParts = divCeil(task.SizeBytes, h.conf.UploadPartsize.Value())
+	// if the file is empty, we still need to upload it, so set the part size to 1
+	task.UploadParts = max(divCeil(task.SizeBytes, h.conf.UploadPartsize.Value()), 1)
 
 	return nil
 }


### PR DESCRIPTION
Resolves this error:

    {"time":"2025-06-10T16:20:12.995795959-07:00","level":"INFO","msg":"http: panic serving 127.0.0.1:46858: n must be positive number\ngoroutine 20 [running]:\nnet/http.(*conn).serve.func1()\n\t/home/jhoblitt/sdk/go1.24.3/src/net/http/server.go:1947 +0xbe\npanic
    ...