### PR TITLE
fix CORS error when accessing /swagger endpoint

### DIFF
--- a/main.go
+++ b/main.go
@@ -40,9 +40,7 @@ func main() {
 	logger.Info("starting s3nd", "version", version.Version)
 
 	r := chi.NewRouter()
-	r.Get("/swagger/*", httpSwagger.Handler(
-		httpSwagger.URL("http://localhost:15555/swagger/doc.json"), // The url pointing to API definition
-	))
+	r.Get("/swagger/*", httpSwagger.Handler())
 	r.Handle("/version", version.NewHandler(&conf))
 	r.Handle("/upload", upload.NewHandler(&conf))
 


### PR DESCRIPTION
User-agents would return a CORS error when /swagger was accessed with a name other than localhost:15555.